### PR TITLE
refactor: improve task_list security and code quality

### DIFF
--- a/app/lib/extra_func/language.dart
+++ b/app/lib/extra_func/language.dart
@@ -86,6 +86,8 @@ enum Language {
       "task_failed": "个任务失败",
       "task_notification_completed": "个记忆任务已完成，点击查看",
       "task_notification_failed": "个记忆任务处理失败，点击查看",
+      "logs_collapse": "收起日志",
+      "logs_expand": "展开日志",
     },
   ),
   en(
@@ -183,6 +185,8 @@ When finally exporting, confirm the settings are 1080p and 30fps.""",
       "task_failed": "task(s) failed",
       "task_notification_completed": "memory task(s) completed, tap to view",
       "task_notification_failed": "memory task(s) failed, tap to view",
+      "logs_collapse": "Collapse logs",
+      "logs_expand": "Expand logs",
     },
   );
 

--- a/app/lib/pages/task_list.dart
+++ b/app/lib/pages/task_list.dart
@@ -36,7 +36,7 @@ class _TaskListPageState extends State<TaskListPage> {
   List<String> _parseLogMsgs(dynamic logs) {
     if (logs == null) return [];
     if (logs is! List) return [];
-    
+
     try {
       final List<String> result = [];
       for (final log in logs) {
@@ -68,66 +68,76 @@ class _TaskListPageState extends State<TaskListPage> {
   void _listenAuthChanges() {
     _authSubscription = Supabase.instance.client.auth.onAuthStateChange.listen((event) {
       if (event.event == AuthChangeEvent.signedOut) {
-        // 用户登出时清空数据
+        _refreshTimer?.cancel();
+        _refreshTimer = null;
         setState(() {
           _tasksByStatus = {};
           _error = textLocalize('error_not_logged_in');
         });
       } else if (event.event == AuthChangeEvent.signedIn) {
-        // 用户登录时刷新数据
         _fetchTasks();
+        _setupAutoRefresh();
       }
     });
   }
 
   void _setupAutoRefresh() {
-    // 每5秒自动刷新一次，实现类似realtime的效果
-    _refreshTimer = Timer.periodic(const Duration(seconds: 5), (timer) {
+    _refreshTimer?.cancel();
+    _refreshTimer = Timer.periodic(const Duration(seconds: 15), (timer) {
       if (mounted) {
         _fetchTasksSilent();
       }
     });
   }
 
+  /// 查询 processing_tasks 并分组，返回分组结果和日志映射
+  Future<({Map<String, List<Map<String, dynamic>>> grouped, Map<String, List<String>> logMap})> _queryAndGroupTasks() async {
+    final userId = Supabase.instance.client.auth.currentUser?.id;
+    if (userId == null) throw Exception(textLocalize('error_not_logged_in'));
+
+    final response = await Supabase.instance.client
+        .from('processing_tasks')
+        .select('*')
+        .eq('user_id', userId)
+        .order('created_at', ascending: false);
+
+    final Map<String, List<Map<String, dynamic>>> grouped = {};
+    final Map<String, List<String>> logMap = {};
+
+    for (final task in response) {
+      final status = task['status']?.toString() ?? 'pending';
+      final taskId = task['id'].toString();
+
+      grouped.putIfAbsent(status, () => []);
+      grouped[status]!.add(Map<String, dynamic>.from(task));
+
+      final logs = task['logs'];
+      if (logs is List) {
+        final parsedLogs = _parseLogMsgs(logs);
+        if (parsedLogs.isNotEmpty) {
+          logMap[taskId] = parsedLogs;
+        }
+      }
+    }
+
+    return (grouped: grouped, logMap: logMap);
+  }
+
   Future<void> _fetchTasksSilent() async {
     try {
-      final response = await Supabase.instance.client
-          .from('processing_tasks')
-          .select('*')
-          .order('created_at', ascending: false);
+      final result = await _queryAndGroupTasks();
 
       if (mounted) {
-        final Map<String, List<Map<String, dynamic>>> grouped = {};
-        final Map<String, List<String>> logMap = {};
-        
-        for (final task in response) {
-          final status = task['status']?.toString() ?? 'pending';
-          final taskId = task['id'].toString();
-          
-          grouped.putIfAbsent(status, () => []);
-          grouped[status]!.add(Map<String, dynamic>.from(task));
-          
-          // 解析 logs
-          final logs = task['logs'];
-          if (logs is List) {
-            final parsedLogs = _parseLogMsgs(logs);
-            if (parsedLogs.isNotEmpty) {
-              logMap[taskId] = parsedLogs;
-            }
-          }
-        }
-
-        for (final status in grouped.keys) {
+        for (final status in result.grouped.keys) {
           _expandedStatus.putIfAbsent(status, () => true);
         }
 
         setState(() {
-          _tasksByStatus = grouped;
-          _taskLogs = logMap;
+          _tasksByStatus = result.grouped;
+          _taskLogs = result.logMap;
         });
 
-        // 标记所有任务为已通知（更新缓存）
-        final allTasks = grouped.values.expand((list) => list).toList();
+        final allTasks = result.grouped.values.expand((list) => list).toList();
         taskNotificationService.markAllTasksAsNotified(allTasks);
       }
     } catch (e) {
@@ -142,45 +152,20 @@ class _TaskListPageState extends State<TaskListPage> {
     });
 
     try {
-      final response = await Supabase.instance.client
-          .from('processing_tasks')
-          .select('*')
-          .order('created_at', ascending: false);
+      final result = await _queryAndGroupTasks();
 
       if (mounted) {
-        final Map<String, List<Map<String, dynamic>>> grouped = {};
-        final Map<String, List<String>> logMap = {};
-        
-        for (final task in response) {
-          final status = task['status']?.toString() ?? 'pending';
-          final taskId = task['id'].toString();
-          
-          grouped.putIfAbsent(status, () => []);
-          grouped[status]!.add(Map<String, dynamic>.from(task));
-          
-          // 解析 logs
-          final logs = task['logs'];
-          if (logs is List) {
-            final parsedLogs = _parseLogMsgs(logs);
-            if (parsedLogs.isNotEmpty) {
-              logMap[taskId] = parsedLogs;
-            }
-          }
-        }
-
-        // 初始化展开状态
-        for (final status in grouped.keys) {
+        for (final status in result.grouped.keys) {
           _expandedStatus.putIfAbsent(status, () => true);
         }
 
         setState(() {
-          _tasksByStatus = grouped;
-          _taskLogs = logMap;
+          _tasksByStatus = result.grouped;
+          _taskLogs = result.logMap;
           _isLoading = false;
         });
 
-        // 标记所有任务为已通知（更新缓存）
-        final allTasks = grouped.values.expand((list) => list).toList();
+        final allTasks = result.grouped.values.expand((list) => list).toList();
         taskNotificationService.markAllTasksAsNotified(allTasks);
       }
     } catch (e) {
@@ -329,6 +314,7 @@ class _TaskListPageState extends State<TaskListPage> {
         tasks: _tasksByStatus[status]!,
         taskLogs: _taskLogs,
         initiallyExpanded: _expandedStatus[status] ?? true,
+        status: status,
         isDark: isDark,
         textColor: textColor,
         onTaskTap: (task) => _onTaskTap(task),

--- a/app/lib/pages/task_list/category_section.dart
+++ b/app/lib/pages/task_list/category_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:tdesign_flutter/tdesign_flutter.dart';
+import '../../configs/app_config.dart';
 
 /// 可展开收起的分类组件
 class ExpandableCategorySection extends StatefulWidget {
@@ -9,6 +10,7 @@ class ExpandableCategorySection extends StatefulWidget {
   final List<Map<String, dynamic>> tasks;
   final Map<String, List<String>> taskLogs; // taskId -> logs
   final bool initiallyExpanded;
+  final String status; // 状态标识
   final Function(Map<String, dynamic>)? onTaskTap;
   final Color? textColor;
   final bool isDark;
@@ -21,6 +23,7 @@ class ExpandableCategorySection extends StatefulWidget {
     required this.tasks,
     this.taskLogs = const {},
     this.initiallyExpanded = true,
+    required this.status,
     this.onTaskTap,
     this.textColor,
     required this.isDark,
@@ -198,7 +201,7 @@ class _ExpandableCategorySectionState extends State<ExpandableCategorySection>
     final taskTypeIcon = _getTaskTypeIcon(taskType);
 
     // 判断是否为 processing 状态（显示加载动画）
-    final isProcessing = widget.color == Colors.blue;
+    final isProcessing = widget.status == 'processing';
     
     // 获取当前任务的logs展开状态
     final isLogsExpanded = _logsExpanded[taskId] ?? false;
@@ -315,8 +318,8 @@ class _ExpandableCategorySectionState extends State<ExpandableCategorySection>
                     const SizedBox(width: 4),
                     Text(
                       isLogsExpanded 
-                          ? '收起日志 (${allLogs.length})' 
-                          : '展开日志 (${allLogs.length})',
+                          ? '${textLocalize('logs_collapse')} (${allLogs.length})'
+                          : '${textLocalize('logs_expand')} (${allLogs.length})',
                       style: TextStyle(
                         fontSize: 12,
                         color: isDark ? const Color(0xFF888888) : theme.fontGyColor3,


### PR DESCRIPTION
- Add user_id filter to processing_tasks queries for defense-in-depth
- Extract _queryAndGroupTasks() to eliminate duplicate fetch logic
- Increase polling interval from 5s to 15s to reduce unnecessary requests
- Cancel timer on sign-out, restart on sign-in
- Replace fragile color-based isProcessing check with status string comparison
- Internationalize log toggle button text (zh/en)