### PR TITLE
feat(app): 优化 Time Peeling 时间轴样式与 display_name 全局替换

### DIFF
--- a/app/lib/pages/community.dart
+++ b/app/lib/pages/community.dart
@@ -1640,6 +1640,7 @@ class CommunityRepository {
           authorName: map['user_id']?.toString() ?? '匿名用户',
           modelName:
               map['model_name']?.toString() ??
+              model['display_name']?.toString() ??
               model['scene_id']?.toString() ??
               '3D 模型',
           modelUrl: modelUrl.isEmpty
@@ -1685,7 +1686,7 @@ class CommunityRepository {
         final publicUrl = _publicModelUrl(path);
         return CommunityModelOption(
           id: map['id'].toString(),
-          sceneId: map['scene_id']?.toString() ?? '未命名模型',
+          sceneId: map['display_name']?.toString() ?? map['scene_id']?.toString() ?? '未命名模型',
           description: map['description']?.toString() ?? '',
           modelUrl: publicUrl.isEmpty
               ? './models/scene_auto_sync_raw.ply'

--- a/app/lib/pages/recall.dart
+++ b/app/lib/pages/recall.dart
@@ -497,7 +497,7 @@ $userQuestion
 
     final parts = <String>[
       '片段$index',
-      '场景：${model['scene_id']?.toString() ?? '未知场景'}',
+      '场景：${model['display_name']?.toString() ?? model['scene_id']?.toString() ?? '未知场景'}',
       '描述：${model['description']?.toString() ?? '暂无描述'}',
       if (tags.isNotEmpty) '标签：$tags',
       if (objects.isNotEmpty) '对象：$objects',
@@ -745,6 +745,30 @@ $userQuestion
           .order('created_at', ascending: false);
 
       final models = List<Map<String, dynamic>>.from(response);
+
+      // 从 processing_tasks 获取 display_name，关联到 model_assets
+      try {
+        final tasks = await Supabase.instance.client
+            .from('processing_tasks')
+            .select('scene_id, display_name');
+        final nameMap = <String, String>{};
+        for (final t in tasks) {
+          final sid = t['scene_id']?.toString();
+          final dn = t['display_name']?.toString();
+          if (sid != null && dn != null && dn.isNotEmpty) {
+            nameMap[sid] = dn;
+          }
+        }
+        for (final m in models) {
+          final sid = m['scene_id']?.toString();
+          if (sid != null && nameMap.containsKey(sid)) {
+            m['display_name'] = nameMap[sid];
+          }
+        }
+      } catch (_) {
+        // display_name 获取失败不影响主流程
+      }
+
       if (models.isEmpty) {
         models.add(_buildDemoModel());
       }
@@ -885,20 +909,9 @@ $userQuestion
                       children: [
                     BDPageHeader(
                       title: textLocalize("home_page"),
-                      subtitle: '把空间、任务和检索线索压进同一条记忆流里。',
                       trailing: Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          BDStatusPill(
-                            label: SupabaseConfig.isAdminMode ? 'ADMIN' : 'RLS',
-                            icon: SupabaseConfig.isAdminMode
-                                ? Icons.admin_panel_settings_rounded
-                                : Icons.verified_user_rounded,
-                            color: SupabaseConfig.isAdminMode
-                                ? BDDesign.colorDarkRed
-                                : BDDesign.colorMutedBlue,
-                          ),
-                          const SizedBox(width: 8),
                           IconButton(
                             icon: AnimatedRotation(
                               turns: _isLoading ? 1 : 0,
@@ -1643,7 +1656,7 @@ $userQuestion
         ? _toPublicUrl(plyPath)
         : './models/scene_auto_sync_raw.ply';
     final posesUrl = plyPath.isNotEmpty ? _toPosesUrl(plyPath) : null;
-    final sceneId = model['scene_id'] ?? 'Unknown Scene';
+    final sceneId = model['display_name'] ?? model['scene_id'] ?? 'Unknown Scene';
     String? initialPoseId;
 
     if (transformMatrix is Map) {
@@ -2073,7 +2086,7 @@ $userQuestion
     final preview = model['preview_img_path']?.toString();
     return CommunityModelOption(
       id: model['id']?.toString() ?? model['scene_id']?.toString() ?? 'model',
-      sceneId: model['scene_id']?.toString() ?? '未命名模型',
+      sceneId: model['display_name']?.toString() ?? model['scene_id']?.toString() ?? '未命名模型',
       description: model['description']?.toString() ?? '',
       modelUrl: plyPath.isEmpty
           ? './models/scene_auto_sync_raw.ply'

--- a/app/lib/pages/recall/model_card.dart
+++ b/app/lib/pages/recall/model_card.dart
@@ -30,7 +30,7 @@ class ModelCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final sceneId = model['scene_id'] ?? 'Unknown Scene';
+    final sceneId = model['display_name'] ?? model['scene_id'] ?? 'Unknown Scene';
     final desc = model['description'] ?? textLocalize("recall_no_desc");
     final similarity = model['similarity'] as double?;
 
@@ -161,7 +161,7 @@ class ModelCard extends StatelessWidget {
         ? toPublicUrl(plyPath)
         : './models/scene_auto_sync_raw.ply';
     final posesUrl = plyPath.isNotEmpty ? toPosesUrl(plyPath) : null;
-    final sceneId = model['scene_id'] ?? 'Unknown Scene';
+    final sceneId = model['display_name'] ?? model['scene_id'] ?? 'Unknown Scene';
 
     dynamic transformMatrix;
     // 如果传入的 matrix 为空，尝试从模型元数据中获取智能初始视角

--- a/app/lib/pages/recall/model_grid.dart
+++ b/app/lib/pages/recall/model_grid.dart
@@ -52,7 +52,7 @@ class RecallModelGrid extends StatelessWidget {
               final model = models[index];
               final cardKey = modelCardKeyFor(model);
               final isActionTarget = isSameModel(activeModelAction, model);
-              final sceneId = model['scene_id'] ?? 'Unknown Scene';
+              final sceneId = model['display_name'] ?? model['scene_id'] ?? 'Unknown Scene';
               final desc = model['description'] ?? '没有描述信息';
               final similarity = model['similarity'] as double?;
               final userId = model['user_id'] ?? '';
@@ -792,6 +792,7 @@ class RecallModelTile extends StatelessWidget {
   final Color textColor;
   final Color hintTextColor;
   final bool elevated;
+  final bool imageOnly;
 
   const RecallModelTile({
     super.key,
@@ -803,18 +804,20 @@ class RecallModelTile extends StatelessWidget {
     required this.textColor,
     required this.hintTextColor,
     this.elevated = false,
+    this.imageOnly = false,
   });
 
   @override
   Widget build(BuildContext context) {
-    final sceneId = model['scene_id'] ?? 'Unknown Scene';
+    final sceneId = model['display_name'] ?? model['scene_id'] ?? 'Unknown Scene';
     final desc = model['description'] ?? textLocalize("recall_no_desc");
     final similarity = model['similarity'] as double?;
+    final radius = BorderRadius.circular(28.0);
 
     return Container(
       decoration: BoxDecoration(
         color: isDark ? darkCard : theme.whiteColor1.withAlpha(220),
-        borderRadius: BorderRadius.circular(28.0),
+        borderRadius: radius,
         boxShadow: [
           BoxShadow(
             color: Colors.black.withAlpha(elevated ? 46 : 20),
@@ -834,9 +837,11 @@ class RecallModelTile extends StatelessWidget {
                 Container(
                   decoration: BoxDecoration(
                     color: isDark ? darkInput : theme.grayColor3,
-                    borderRadius: const BorderRadius.vertical(
-                      top: Radius.circular(28.0),
-                    ),
+                    borderRadius: imageOnly
+                        ? radius
+                        : const BorderRadius.vertical(
+                            top: Radius.circular(28.0),
+                          ),
                   ),
                   clipBehavior: Clip.hardEdge,
                   child:
@@ -879,28 +884,29 @@ class RecallModelTile extends StatelessWidget {
               ],
             ),
           ),
-          Padding(
-            padding: const EdgeInsets.all(12.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                TDText(
-                  sceneId,
-                  font: theme.fontTitleMedium,
-                  fontWeight: FontWeight.w600,
-                  maxLines: 1,
-                  textColor: textColor,
-                ),
-                const SizedBox(height: 4),
-                TDText(
-                  desc,
-                  font: theme.fontBodySmall,
-                  textColor: hintTextColor,
-                  maxLines: 2,
-                ),
-              ],
+          if (!imageOnly)
+            Padding(
+              padding: const EdgeInsets.all(12.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  TDText(
+                    sceneId,
+                    font: theme.fontTitleMedium,
+                    fontWeight: FontWeight.w600,
+                    maxLines: 1,
+                    textColor: textColor,
+                  ),
+                  const SizedBox(height: 4),
+                  TDText(
+                    desc,
+                    font: theme.fontBodySmall,
+                    textColor: hintTextColor,
+                    maxLines: 2,
+                  ),
+                ],
+              ),
             ),
-          ),
         ],
       ),
     );
@@ -1034,6 +1040,14 @@ class TimePeelingList extends StatelessWidget {
   }
 }
 
+const double _kCardWidth = 170.0;
+const double _kCardGap = 12.0;
+const double _kSlotWidth = _kCardWidth + _kCardGap;
+const double _kTimelineHeight = 58.0;
+const double _kNodeRadius = 7.0;
+const double _kLineHeight = 3.5;
+const Color _kTimelineColor = Color(0xFFCC9A5C); // 橙色微灰
+
 class _TimePeelingSlot extends StatelessWidget {
   final String name;
   final List<Map<String, dynamic>> models;
@@ -1069,11 +1083,20 @@ class _TimePeelingSlot extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final lineColor = _kTimelineColor.withValues(alpha: 0.6);
+    final nodeColor = _kTimelineColor.withValues(alpha: 0.95);
+    final timeStyle = TextStyle(
+      fontSize: 11,
+      fontWeight: FontWeight.w500,
+      color: _kTimelineColor.withValues(alpha: 0.8),
+    );
+
     return Padding(
       padding: const EdgeInsets.only(bottom: 20),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // 标题行
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 20),
             child: Row(
@@ -1110,8 +1133,9 @@ class _TimePeelingSlot extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 10),
+          // 卡片 + 时间轴，统一水平滚动
           SizedBox(
-            height: 220,
+            height: 220 + 10 + _kTimelineHeight,
             child: ListView.builder(
               scrollDirection: Axis.horizontal,
               padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -1120,31 +1144,64 @@ class _TimePeelingSlot extends StatelessWidget {
                 final model = models[i];
                 final cardKey = modelCardKeyFor(model);
                 final isActionTarget = isSameModel(activeModelAction, model);
+                final dt = DateTime.tryParse(
+                  model['created_at']?.toString() ?? '',
+                );
+                final timeLabel = dt != null
+                    ? '${dt.toLocal().month.toString().padLeft(2, '0')}/${dt.toLocal().day.toString().padLeft(2, '0')} ${dt.toLocal().hour.toString().padLeft(2, '0')}:${dt.toLocal().minute.toString().padLeft(2, '0')}'
+                    : '--';
 
-                return RepaintBoundary(
-                  child: IgnorePointer(
-                    ignoring: isActionTarget,
-                    child: Opacity(
-                      opacity: isActionTarget ? 0.0 : 1.0,
-                      child: GestureDetector(
-                        onTap: () => onNavigateToViewer(model, null),
-                        onLongPressStart: (_) => onShowModelActions(model),
-                        child: Container(
-                          key: cardKey,
-                          width: 170,
-                          margin: const EdgeInsets.only(right: 12),
-                          child: RecallModelTile(
-                            model: model,
-                            theme: theme,
-                            isDark: isDark,
-                            darkCard: darkCard,
-                            darkInput: darkInput,
-                            textColor: textColor,
-                            hintTextColor: hintTextColor,
+                return SizedBox(
+                  width: _kSlotWidth,
+                  child: Column(
+                    children: [
+                      // 卡片
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.only(right: _kCardGap),
+                          child: RepaintBoundary(
+                            child: IgnorePointer(
+                              ignoring: isActionTarget,
+                              child: Opacity(
+                                opacity: isActionTarget ? 0.0 : 1.0,
+                                child: GestureDetector(
+                                  onTap: () => onNavigateToViewer(model, null),
+                                  onLongPressStart: (_) =>
+                                      onShowModelActions(model),
+                                  child: Container(
+                                    key: cardKey,
+                                    child: RecallModelTile(
+                                      model: model,
+                                      theme: theme,
+                                      isDark: isDark,
+                                      darkCard: darkCard,
+                                      darkInput: darkInput,
+                                      textColor: textColor,
+                                      hintTextColor: hintTextColor,
+                                      imageOnly: true,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
                           ),
                         ),
                       ),
-                    ),
+                      // 卡片与时间轴间距
+                      const SizedBox(height: 10),
+                      // 时间轴
+                      SizedBox(
+                        height: _kTimelineHeight,
+                        child: _TimelineNode(
+                          isFirst: i == 0,
+                          isLast: i == models.length - 1,
+                          lineColor: lineColor,
+                          nodeColor: nodeColor,
+                          timeLabel: timeLabel,
+                          timeStyle: timeStyle,
+                        ),
+                      ),
+                    ],
                   ),
                 );
               },
@@ -1152,6 +1209,75 @@ class _TimePeelingSlot extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// 单个时间轴节点：横线 + 圆点 + 时间标签
+class _TimelineNode extends StatelessWidget {
+  final bool isFirst;
+  final bool isLast;
+  final Color lineColor;
+  final Color nodeColor;
+  final String timeLabel;
+  final TextStyle timeStyle;
+
+  const _TimelineNode({
+    required this.isFirst,
+    required this.isLast,
+    required this.lineColor,
+    required this.nodeColor,
+    required this.timeLabel,
+    required this.timeStyle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // 横线 + 节点
+        SizedBox(
+          height: _kNodeRadius * 2 + 4,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              // 横线
+              Positioned(
+                left: isFirst ? _kSlotWidth / 2 : 0,
+                right: isLast ? _kSlotWidth / 2 : 0,
+                child: Container(
+                  height: _kLineHeight,
+                  color: lineColor,
+                ),
+              ),
+              // 圆点，居中于卡片（含 gap 的一半偏移）
+              Positioned(
+                left: (_kCardWidth - _kNodeRadius * 2) / 2,
+                child: Container(
+                  width: _kNodeRadius * 2,
+                  height: _kNodeRadius * 2,
+                  decoration: BoxDecoration(
+                    color: nodeColor,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 10),
+        // 时间标签，居中于卡片
+        SizedBox(
+          width: _kCardWidth,
+          child: Text(
+            timeLabel,
+            textAlign: TextAlign.center,
+            style: timeStyle,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/app/lib/pages/recall/result_card.dart
+++ b/app/lib/pages/recall/result_card.dart
@@ -29,7 +29,7 @@ class SearchResultCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final sceneId = model['scene_id'] ?? 'Unknown Scene';
+    final sceneId = model['display_name'] ?? model['scene_id'] ?? 'Unknown Scene';
     final desc = model['description'] ?? '没有描述信息';
     final similarity = model['similarity'] as double?;
     final userId = model['user_id'] ?? '';
@@ -193,7 +193,7 @@ class SearchResultCard extends StatelessWidget {
         ? toPublicUrl(plyPath)
         : './models/scene_auto_sync_raw.ply';
     final posesUrl = plyPath.isNotEmpty ? toPosesUrl(plyPath) : null;
-    final sceneId = model['scene_id'] ?? 'Unknown Scene';
+    final sceneId = model['display_name'] ?? model['scene_id'] ?? 'Unknown Scene';
     String? initialPoseId;
 
     if (transformMatrix is Map) {

--- a/app/lib/services/local_rag_index.dart
+++ b/app/lib/services/local_rag_index.dart
@@ -225,6 +225,7 @@ List<Map<String, dynamic>> _searchRows(Map<String, dynamic> payload) {
 
 String _buildSearchableTextStatic(Map<String, dynamic> model) {
   final parts = <String>[
+    model['display_name']?.toString() ?? '',
     model['scene_id']?.toString() ?? '',
     model['description']?.toString() ?? '',
     ..._stringListStatic(model['tags']),


### PR DESCRIPTION
- 加粗时间轴线条与节点，颜色调整为更鲜明的暖橙色
- 扩大卡片与时间轴、节点与标签的间距
- 时间槽卡片改为纯图片模式（imageOnly）
- 移除 recall 页面副标题及 ADMIN/RLS 状态标签
- 全局使用 processing_tasks.display_name 替代 scene_id 作为模型显示名
- 本地搜索索引纳入 display_name 字段